### PR TITLE
Clue spawner

### DIFF
--- a/My project/Assets/Scripts/GameController.cs
+++ b/My project/Assets/Scripts/GameController.cs
@@ -6,10 +6,12 @@ using UnityEngine;
 public class GameController : MonoBehaviour
 {
     [SerializeField] private UIController uIController;
+    
 
     List<ClueScriptableObject> activeClues;
 
     // public TextAsset spawnPointsFile;
+    [SerializeField] private GameObject zones;
 
     public List<Vector3> spawnPoints;
 
@@ -170,6 +172,9 @@ public class GameController : MonoBehaviour
     }
     void PlaceClue(ClueScriptableObject clue)
     {
+
+
+
         int i;
         List<Vector3> activeSpawnPoints;
         if (clue.defaultSpawnPoints.Count() != 0)
@@ -181,6 +186,8 @@ public class GameController : MonoBehaviour
             activeSpawnPoints = spawnPoints;
         }
         i = UnityEngine.Random.Range(0, clue.defaultSpawnPoints.Count());
+
+
 
 
         GameObject currentClue = Instantiate(clue.model, activeSpawnPoints[i], Quaternion.identity);

--- a/My project/Assets/Scripts/GameController.cs
+++ b/My project/Assets/Scripts/GameController.cs
@@ -173,7 +173,7 @@ public class GameController : MonoBehaviour
     void PlaceClue(ClueScriptableObject clue)
     {
 
-        Vector3 spawnPoint = getSpawnPointFromRandomZone();
+        Vector3 spawnPoint = GetSpawnPointFromRandomZone();
 
         GameObject currentClue = Instantiate(clue.model, spawnPoint, Quaternion.identity);
         Clue clueObject = currentClue.GetComponent<Clue>();
@@ -187,7 +187,7 @@ public class GameController : MonoBehaviour
         }
         currentClue.name = clue.clueName;
     }
-    private Vector3 getSpawnPointFromRandomZone()
+    private Vector3 GetSpawnPointFromRandomZone()
     {
         bool cluePlaced = false;
         while (!cluePlaced)

--- a/My project/Assets/Scripts/GameController.cs
+++ b/My project/Assets/Scripts/GameController.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 public class GameController : MonoBehaviour
 {
     [SerializeField] private UIController uIController;
-    
+
 
     List<ClueScriptableObject> activeClues;
 
@@ -73,7 +73,7 @@ public class GameController : MonoBehaviour
 
         // DebugSpawnPoints(suspect.suspectClues[0]);
         uIController.InitializeDossier(allSuspects);
-        
+
 
     }
 
@@ -96,10 +96,10 @@ public class GameController : MonoBehaviour
         {
             Debug.Log("All clues found.");
         }
-            OnScoreLimitReached();
+        OnScoreLimitReached();
 
     }
-    
+
 
     private void OnScoreLimitReached()
     {
@@ -107,7 +107,7 @@ public class GameController : MonoBehaviour
         {
             int numberToPress = i;
             numberToPress += 1;
-            Debug.Log("Suspect " + numberToPress+ ": " + allSuspects[i].suspectName);
+            Debug.Log("Suspect " + numberToPress + ": " + allSuspects[i].suspectName);
         }
 
         Debug.Log("Press the number of the suspect you want to pick.");
@@ -132,7 +132,7 @@ public class GameController : MonoBehaviour
         {
             Debug.Log("You picked the wrong suspect");
         }
-        
+
     }
 
 
@@ -173,24 +173,9 @@ public class GameController : MonoBehaviour
     void PlaceClue(ClueScriptableObject clue)
     {
 
+        Vector3 spawnPoint = getSpawnPointFromRandomZone();
 
-
-        int i;
-        List<Vector3> activeSpawnPoints;
-        if (clue.defaultSpawnPoints.Count() != 0)
-        {
-            activeSpawnPoints = clue.defaultSpawnPoints;
-        }
-        else
-        {
-            activeSpawnPoints = spawnPoints;
-        }
-        i = UnityEngine.Random.Range(0, clue.defaultSpawnPoints.Count());
-
-
-
-
-        GameObject currentClue = Instantiate(clue.model, activeSpawnPoints[i], Quaternion.identity);
+        GameObject currentClue = Instantiate(clue.model, spawnPoint, Quaternion.identity);
         Clue clueObject = currentClue.GetComponent<Clue>();
         if (clueObject != null)
         {
@@ -201,6 +186,22 @@ public class GameController : MonoBehaviour
             Debug.LogWarning($"No clue script found on clue prefab {clue.name}");
         }
         currentClue.name = clue.clueName;
-        activeSpawnPoints.RemoveAt(i);
+    }
+    private Vector3 getSpawnPointFromRandomZone()
+    {
+        bool cluePlaced = false;
+        while (!cluePlaced)
+        {
+            int i = Random.Range(0, zones.transform.childCount);
+            Zone zone = zones.transform.GetChild(i).GetComponent<Zone>();
+            if (zone.AddClueToZone())
+            {
+                return zone.getSpawnPoint();
+            }
+            
+        }
+        Debug.LogWarning("Could not find a spawn point");
+        return new Vector3(0, 0, 0);
     }
 }
+

--- a/My project/Assets/Scripts/Zone.cs
+++ b/My project/Assets/Scripts/Zone.cs
@@ -12,6 +12,12 @@ public class Zone : MonoBehaviour
 
     }
 
+    /// <summary>
+    /// Add a clue to the zone if the max number of clues in this zone has not been reached.
+    /// Call <c> GetSpawnPoint</c> to get a valid location to place the clue.
+    /// </summary>
+    /// <returns> True if a clue can be placed within this zone, and 
+    /// false if the max number of clues has already been placed.</returns>
     public bool AddClueToZone()
     {
         //returns false if 
@@ -24,6 +30,13 @@ public class Zone : MonoBehaviour
         return true;
     }
 
+    /// <summary>
+    /// Locates a valid spawn point within this zone.
+    /// </summary>
+    /// <returns>
+    /// A Vector3 containing a valid spawn point. If the zone has manually set spawn points, this will be one of these.
+    /// If not, a spawn point will be determined within the bounds of the GameObject.
+    /// </returns>
     public Vector3 getSpawnPoint()
     {
         if (spawnPoints.Count != 0)

--- a/My project/Assets/Scripts/Zone.cs
+++ b/My project/Assets/Scripts/Zone.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Zone : MonoBehaviour
+{
+    [SerializeField] int maxNumberOfClues;
+    [SerializeField] List<Vector3> spawnPoints;
+    private int numOfClues;
+    // Start is called once before the first execution of Update after the MonoBehaviour is created
+    void Start()
+    {
+
+    }
+
+    public bool AddClueToZone()
+    {
+        //returns false if 
+        if (numOfClues == maxNumberOfClues)
+        {
+            return false;
+        }
+
+        numOfClues++;
+        return true;
+    }
+
+    public Vector3 getSpawnPoint()
+    {
+        if (spawnPoints.Count != 0)
+        {
+            int i = Random.Range(0, spawnPoints.Count);
+            return spawnPoints[i];
+        }
+        float minX = transform.position.x - transform.lossyScale.x / 2;
+        float maxX = transform.position.x + transform.lossyScale.x / 2;
+
+        float minZ = transform.position.z - transform.lossyScale.z / 2;
+        float maxZ = transform.position.z + transform.lossyScale.z / 2;
+
+        float x = Random.Range(minX, maxX);
+        float z = Random.Range(minZ, maxZ);
+
+        return new Vector3(x, 0.5f, z);
+    }
+    
+}

--- a/My project/Assets/Scripts/Zone.cs.meta
+++ b/My project/Assets/Scripts/Zone.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 09b0f6defa2722c4aa1517ea8f26b613

--- a/My project/Assets/test.unity
+++ b/My project/Assets/test.unity
@@ -151,7 +151,6 @@ GameObject:
   m_Component:
   - component: {fileID: 207986195}
   - component: {fileID: 207986197}
-  - component: {fileID: 207986196}
   - component: {fileID: 207986198}
   m_Layer: 0
   m_Name: Alley3
@@ -175,27 +174,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 641049425}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!65 &207986196
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 207986194}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!33 &207986197
 MeshFilter:
   m_ObjectHideFlags: 0
@@ -514,7 +492,6 @@ GameObject:
   m_Component:
   - component: {fileID: 763613873}
   - component: {fileID: 763613875}
-  - component: {fileID: 763613874}
   - component: {fileID: 763613876}
   m_Layer: 0
   m_Name: AlleySide
@@ -538,27 +515,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 641049425}
   m_LocalEulerAnglesHint: {x: 0, y: -90, z: 0}
---- !u!65 &763613874
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 763613872}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!33 &763613875
 MeshFilter:
   m_ObjectHideFlags: 0
@@ -686,7 +642,6 @@ GameObject:
   m_Component:
   - component: {fileID: 887408632}
   - component: {fileID: 887408634}
-  - component: {fileID: 887408633}
   - component: {fileID: 887408635}
   m_Layer: 0
   m_Name: BarRear
@@ -710,27 +665,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 641049425}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!65 &887408633
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 887408631}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!33 &887408634
 MeshFilter:
   m_ObjectHideFlags: 0
@@ -807,7 +741,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1061215513}
   - component: {fileID: 1061215515}
-  - component: {fileID: 1061215514}
   - component: {fileID: 1061215516}
   m_Layer: 0
   m_Name: Bar
@@ -831,27 +764,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 641049425}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!65 &1061215514
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1061215512}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!33 &1061215515
 MeshFilter:
   m_ObjectHideFlags: 0
@@ -1204,7 +1116,7 @@ PrefabInstance:
     - target: {fileID: 7197864777881572663, guid: 836330f190b2eb844805ea81ce8e9b9d,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -76.5463
+      value: -71.81
       objectReference: {fileID: 0}
     - target: {fileID: 7197864777881572663, guid: 836330f190b2eb844805ea81ce8e9b9d,
         type: 3}
@@ -1739,7 +1651,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1607087218}
   - component: {fileID: 1607087220}
-  - component: {fileID: 1607087219}
   - component: {fileID: 1607087221}
   m_Layer: 0
   m_Name: AlleyRear
@@ -1763,27 +1674,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 641049425}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!65 &1607087219
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1607087217}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!33 &1607087220
 MeshFilter:
   m_ObjectHideFlags: 0
@@ -1838,7 +1728,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1714669453}
   - component: {fileID: 1714669455}
-  - component: {fileID: 1714669454}
   - component: {fileID: 1714669456}
   m_Layer: 0
   m_Name: BarToilets
@@ -1862,27 +1751,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 641049425}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!65 &1714669454
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1714669452}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!33 &1714669455
 MeshFilter:
   m_ObjectHideFlags: 0
@@ -1923,7 +1791,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1717280192}
   - component: {fileID: 1717280194}
-  - component: {fileID: 1717280193}
   - component: {fileID: 1717280195}
   m_Layer: 0
   m_Name: Alley1
@@ -1947,27 +1814,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 641049425}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!65 &1717280193
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1717280191}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!33 &1717280194
 MeshFilter:
   m_ObjectHideFlags: 0
@@ -2802,7 +2648,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1947350966}
   - component: {fileID: 1947350968}
-  - component: {fileID: 1947350967}
   - component: {fileID: 1947350969}
   m_Layer: 0
   m_Name: Alley2
@@ -2826,27 +2671,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 641049425}
   m_LocalEulerAnglesHint: {x: 0, y: -90, z: 0}
---- !u!65 &1947350967
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1947350965}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!33 &1947350968
 MeshFilter:
   m_ObjectHideFlags: 0

--- a/My project/Assets/test.unity
+++ b/My project/Assets/test.unity
@@ -141,6 +141,68 @@ MeshCollider:
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: 7253688876945581161, guid: b438203077c5af34e97ec5c9829c4f4b, type: 3}
+--- !u!1 &207986194
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 207986195}
+  - component: {fileID: 207986197}
+  - component: {fileID: 207986196}
+  m_Layer: 0
+  m_Name: Alley3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &207986195
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 207986194}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 32.85, y: 11.83, z: -6.42}
+  m_LocalScale: {x: 29.57823, y: 4.3879, z: 3.6393497}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 641049425}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &207986196
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 207986194}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &207986197
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 207986194}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!64 &224680977
 MeshCollider:
   m_ObjectHideFlags: 0
@@ -258,7 +320,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e48354bc246d89e48a1baf0eb6b5e6ad, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  uIController: {fileID: 1230300914}
   spawnPoints:
   - {x: -73, y: 0.5, z: -64}
   - {x: -73, y: 0.5, z: -57}
@@ -343,6 +404,45 @@ MeshCollider:
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: -11537632214982194, guid: b438203077c5af34e97ec5c9829c4f4b, type: 3}
+--- !u!1 &641049424
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 641049425}
+  m_Layer: 0
+  m_Name: Zones
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &641049425
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 641049424}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -113.57653, y: -10.08104, z: -42.176575}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1607087218}
+  - {fileID: 1717280192}
+  - {fileID: 1947350966}
+  - {fileID: 207986195}
+  - {fileID: 1061215513}
+  - {fileID: 887408632}
+  - {fileID: 1714669453}
+  - {fileID: 763613873}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!64 &672760896
 MeshCollider:
   m_ObjectHideFlags: 0
@@ -387,6 +487,68 @@ MeshCollider:
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: -1362129810762785342, guid: b438203077c5af34e97ec5c9829c4f4b, type: 3}
+--- !u!1 &763613872
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 763613873}
+  - component: {fileID: 763613875}
+  - component: {fileID: 763613874}
+  m_Layer: 0
+  m_Name: AlleySide
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &763613873
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 763613872}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0.70710576, z: -0, w: 0.7071079}
+  m_LocalPosition: {x: 15.93, y: 11.83, z: -0.38}
+  m_LocalScale: {x: 6.4289346, y: 4.3879, z: 3.6393497}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 641049425}
+  m_LocalEulerAnglesHint: {x: 0, y: -90, z: 0}
+--- !u!65 &763613874
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 763613872}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &763613875
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 763613872}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1001 &794448958
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -482,6 +644,68 @@ MeshCollider:
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: 3562073674547505438, guid: b438203077c5af34e97ec5c9829c4f4b, type: 3}
+--- !u!1 &887408631
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 887408632}
+  - component: {fileID: 887408634}
+  - component: {fileID: 887408633}
+  m_Layer: 0
+  m_Name: BarRear
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &887408632
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 887408631}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 21.49, y: 11.83, z: -20.81}
+  m_LocalScale: {x: 6.4366894, y: 4.3879, z: 12.114964}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 641049425}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &887408633
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 887408631}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &887408634
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 887408631}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!64 &972921150
 MeshCollider:
   m_ObjectHideFlags: 0
@@ -526,6 +750,68 @@ MeshCollider:
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: 6854844108466458566, guid: b438203077c5af34e97ec5c9829c4f4b, type: 3}
+--- !u!1 &1061215512
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1061215513}
+  - component: {fileID: 1061215515}
+  - component: {fileID: 1061215514}
+  m_Layer: 0
+  m_Name: Bar
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1061215513
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1061215512}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 36.77, y: 11.83, z: -18.07}
+  m_LocalScale: {x: 23.316692, y: 4.3879, z: 17.87394}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 641049425}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &1061215514
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1061215512}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &1061215515
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1061215512}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!64 &1083470713
 MeshCollider:
   m_ObjectHideFlags: 0
@@ -1255,6 +1541,68 @@ MeshCollider:
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: 3709182657909504586, guid: b438203077c5af34e97ec5c9829c4f4b, type: 3}
+--- !u!1 &1607087217
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1607087218}
+  - component: {fileID: 1607087220}
+  - component: {fileID: 1607087219}
+  m_Layer: 0
+  m_Name: AlleyRear
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1607087218
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1607087217}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -5.55, y: 11.83, z: -18.88}
+  m_LocalScale: {x: 12.53364, y: 4.3879, z: 15.165376}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 641049425}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &1607087219
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1607087217}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &1607087220
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1607087217}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!64 &1641863701
 MeshCollider:
   m_ObjectHideFlags: 0
@@ -1277,6 +1625,130 @@ MeshCollider:
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: -8842775135706643524, guid: b438203077c5af34e97ec5c9829c4f4b, type: 3}
+--- !u!1 &1714669452
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1714669453}
+  - component: {fileID: 1714669455}
+  - component: {fileID: 1714669454}
+  m_Layer: 0
+  m_Name: BarToilets
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1714669453
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1714669452}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 21.59, y: 11.83, z: -11.47}
+  m_LocalScale: {x: 6.141917, y: 4.3879, z: 5.87002}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 641049425}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &1714669454
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1714669452}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &1714669455
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1714669452}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1717280191
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1717280192}
+  - component: {fileID: 1717280194}
+  - component: {fileID: 1717280193}
+  m_Layer: 0
+  m_Name: Alley1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1717280192
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1717280191}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 6.96, y: 11.83, z: -24.39}
+  m_LocalScale: {x: 11.664557, y: 4.3879, z: 3.6393497}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 641049425}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &1717280193
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1717280191}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &1717280194
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1717280191}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!64 &1722486423
 MeshCollider:
   m_ObjectHideFlags: 0
@@ -2079,6 +2551,68 @@ MeshCollider:
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: -7926288961201184339, guid: b438203077c5af34e97ec5c9829c4f4b, type: 3}
+--- !u!1 &1947350965
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1947350966}
+  - component: {fileID: 1947350968}
+  - component: {fileID: 1947350967}
+  m_Layer: 0
+  m_Name: Alley2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1947350966
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1947350965}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0.70710576, z: -0, w: 0.7071079}
+  m_LocalPosition: {x: 15.93, y: 11.83, z: -15.1}
+  m_LocalScale: {x: 23.021322, y: 4.3879, z: 3.6393497}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 641049425}
+  m_LocalEulerAnglesHint: {x: 0, y: -90, z: 0}
+--- !u!65 &1947350967
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1947350965}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &1947350968
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1947350965}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!64 &1948594190
 MeshCollider:
   m_ObjectHideFlags: 0
@@ -2177,3 +2711,4 @@ SceneRoots:
   - {fileID: 794448958}
   - {fileID: 1771259308}
   - {fileID: 1230300915}
+  - {fileID: 641049425}

--- a/My project/Assets/test.unity
+++ b/My project/Assets/test.unity
@@ -152,6 +152,7 @@ GameObject:
   - component: {fileID: 207986195}
   - component: {fileID: 207986197}
   - component: {fileID: 207986196}
+  - component: {fileID: 207986198}
   m_Layer: 0
   m_Name: Alley3
   m_TagString: Untagged
@@ -203,6 +204,20 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 207986194}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &207986198
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 207986194}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09b0f6defa2722c4aa1517ea8f26b613, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maxNumberOfClues: 1
+  spawnPoints: []
 --- !u!64 &224680977
 MeshCollider:
   m_ObjectHideFlags: 0
@@ -320,6 +335,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e48354bc246d89e48a1baf0eb6b5e6ad, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  uIController: {fileID: 1230300914}
+  zones: {fileID: 641049424}
   spawnPoints:
   - {x: -73, y: 0.5, z: -64}
   - {x: -73, y: 0.5, z: -57}
@@ -498,6 +515,7 @@ GameObject:
   - component: {fileID: 763613873}
   - component: {fileID: 763613875}
   - component: {fileID: 763613874}
+  - component: {fileID: 763613876}
   m_Layer: 0
   m_Name: AlleySide
   m_TagString: Untagged
@@ -549,6 +567,20 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 763613872}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &763613876
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 763613872}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09b0f6defa2722c4aa1517ea8f26b613, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maxNumberOfClues: 1
+  spawnPoints: []
 --- !u!1001 &794448958
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -655,6 +687,7 @@ GameObject:
   - component: {fileID: 887408632}
   - component: {fileID: 887408634}
   - component: {fileID: 887408633}
+  - component: {fileID: 887408635}
   m_Layer: 0
   m_Name: BarRear
   m_TagString: Untagged
@@ -706,6 +739,20 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 887408631}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &887408635
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 887408631}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09b0f6defa2722c4aa1517ea8f26b613, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maxNumberOfClues: 1
+  spawnPoints: []
 --- !u!64 &972921150
 MeshCollider:
   m_ObjectHideFlags: 0
@@ -761,6 +808,7 @@ GameObject:
   - component: {fileID: 1061215513}
   - component: {fileID: 1061215515}
   - component: {fileID: 1061215514}
+  - component: {fileID: 1061215516}
   m_Layer: 0
   m_Name: Bar
   m_TagString: Untagged
@@ -812,6 +860,38 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1061215512}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &1061215516
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1061215512}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09b0f6defa2722c4aa1517ea8f26b613, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maxNumberOfClues: 1
+  spawnPoints:
+  - {x: -66.9, y: 0.5, z: -52.5}
+  - {x: -68.03, y: 0.5, z: -58.12}
+  - {x: -65.96, y: 0.5, z: -65.37}
+  - {x: -77.83, y: 0.5, z: -62.36}
+  - {x: -78.02, y: 0.5, z: -57.47}
+  - {x: -83.05, y: 0.5, z: -58.6}
+  - {x: -82.79, y: 0.5, z: -56.17}
+  - {x: -82.71, y: 0.5, z: -63.74}
+  - {x: -80.38, y: 0.5, z: -63.74}
+  - {x: -86.96, y: 0.5, z: -68.06}
+  - {x: -76.89, y: 0.5, z: -68.12}
+  - {x: -86.78, y: 0.5, z: -53.06}
+  - {x: -80.17, y: 0.5, z: -51.55}
+  - {x: -78.04, y: 0.5, z: -53.02}
+  - {x: -72.33, y: 0.5, z: -56.61}
+  - {x: -68.32, y: 0.5, z: -60.38}
+  - {x: -72.7, y: 0.5, z: -63.31}
+  - {x: -70.57, y: 0.5, z: -56.01}
 --- !u!64 &1083470713
 MeshCollider:
   m_ObjectHideFlags: 0
@@ -1519,6 +1599,114 @@ MeshCollider:
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: 4125523506836095290, guid: b438203077c5af34e97ec5c9829c4f4b, type: 3}
+--- !u!1 &1485359759
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1485359763}
+  - component: {fileID: 1485359762}
+  - component: {fileID: 1485359761}
+  - component: {fileID: 1485359760}
+  m_Layer: 0
+  m_Name: Cube (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &1485359760
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1485359759}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1485359761
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1485359759}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1485359762
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1485359759}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1485359763
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1485359759}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -94.42, y: 0.5, z: -53.95}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!64 &1597617313
 MeshCollider:
   m_ObjectHideFlags: 0
@@ -1552,6 +1740,7 @@ GameObject:
   - component: {fileID: 1607087218}
   - component: {fileID: 1607087220}
   - component: {fileID: 1607087219}
+  - component: {fileID: 1607087221}
   m_Layer: 0
   m_Name: AlleyRear
   m_TagString: Untagged
@@ -1568,7 +1757,7 @@ Transform:
   m_GameObject: {fileID: 1607087217}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -5.55, y: 11.83, z: -18.88}
+  m_LocalPosition: {x: -5.55, y: 13.53, z: -18.88}
   m_LocalScale: {x: 12.53364, y: 4.3879, z: 15.165376}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1603,6 +1792,20 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1607087217}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &1607087221
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1607087217}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09b0f6defa2722c4aa1517ea8f26b613, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maxNumberOfClues: 1
+  spawnPoints: []
 --- !u!64 &1641863701
 MeshCollider:
   m_ObjectHideFlags: 0
@@ -1636,6 +1839,7 @@ GameObject:
   - component: {fileID: 1714669453}
   - component: {fileID: 1714669455}
   - component: {fileID: 1714669454}
+  - component: {fileID: 1714669456}
   m_Layer: 0
   m_Name: BarToilets
   m_TagString: Untagged
@@ -1687,6 +1891,28 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1714669452}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &1714669456
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1714669452}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09b0f6defa2722c4aa1517ea8f26b613, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maxNumberOfClues: 1
+  spawnPoints:
+  - {x: -89.49, y: 0.5, z: -51.8}
+  - {x: -91.18, y: 0.5, z: -51.87}
+  - {x: -92.94, y: 0.5, z: -51.83}
+  - {x: -94.49, y: 0.5, z: -51.84}
+  - {x: -94.504, y: 0.5, z: -55.881}
+  - {x: -92.8, y: 0.5, z: -55.8}
+  - {x: -91.08, y: 0.5, z: -55.76}
+  - {x: -94.42, y: 0.5, z: -53.95}
 --- !u!1 &1717280191
 GameObject:
   m_ObjectHideFlags: 0
@@ -1698,6 +1924,7 @@ GameObject:
   - component: {fileID: 1717280192}
   - component: {fileID: 1717280194}
   - component: {fileID: 1717280193}
+  - component: {fileID: 1717280195}
   m_Layer: 0
   m_Name: Alley1
   m_TagString: Untagged
@@ -1749,6 +1976,20 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1717280191}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &1717280195
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1717280191}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09b0f6defa2722c4aa1517ea8f26b613, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maxNumberOfClues: 1
+  spawnPoints: []
 --- !u!64 &1722486423
 MeshCollider:
   m_ObjectHideFlags: 0
@@ -2562,6 +2803,7 @@ GameObject:
   - component: {fileID: 1947350966}
   - component: {fileID: 1947350968}
   - component: {fileID: 1947350967}
+  - component: {fileID: 1947350969}
   m_Layer: 0
   m_Name: Alley2
   m_TagString: Untagged
@@ -2613,6 +2855,20 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1947350965}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &1947350969
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1947350965}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09b0f6defa2722c4aa1517ea8f26b613, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maxNumberOfClues: 1
+  spawnPoints: []
 --- !u!64 &1948594190
 MeshCollider:
   m_ObjectHideFlags: 0
@@ -2712,3 +2968,4 @@ SceneRoots:
   - {fileID: 1771259308}
   - {fileID: 1230300915}
   - {fileID: 641049425}
+  - {fileID: 1485359763}

--- a/My project/UserSettings/Layouts/default-6000.dwlt
+++ b/My project/UserSettings/Layouts/default-6000.dwlt
@@ -15,9 +15,9 @@ MonoBehaviour:
   m_PixelRect:
     serializedVersion: 2
     x: 8
-    y: 51
+    y: 50.4
     width: 2544
-    height: 1333
+    height: 1046.4
   m_ShowMode: 4
   m_Title: Project
   m_RootView: {fileID: 2}
@@ -45,7 +45,7 @@ MonoBehaviour:
     x: 0
     y: 0
     width: 2544
-    height: 1333
+    height: 1046.4
   m_MinSize: {x: 875, y: 300}
   m_MaxSize: {x: 10000, y: 10000}
   m_UseTopView: 1
@@ -90,7 +90,7 @@ MonoBehaviour:
   m_Position:
     serializedVersion: 2
     x: 0
-    y: 1313
+    y: 1026.4
     width: 2544
     height: 20
   m_MinSize: {x: 0, y: 0}
@@ -115,7 +115,7 @@ MonoBehaviour:
     x: 0
     y: 36
     width: 2544
-    height: 1277
+    height: 990.4
   m_MinSize: {x: 300, y: 100}
   m_MaxSize: {x: 24288, y: 16192}
   vertical: 0
@@ -140,8 +140,8 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 1973
-    height: 1277
+    width: 1972.8
+    height: 990.4
   m_MinSize: {x: 200, y: 100}
   m_MaxSize: {x: 16192, y: 16192}
   vertical: 1
@@ -166,8 +166,8 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 1973
-    height: 879
+    width: 1972.8
+    height: 682.4
   m_MinSize: {x: 200, y: 50}
   m_MaxSize: {x: 16192, y: 8096}
   vertical: 0
@@ -190,8 +190,8 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 303
-    height: 879
+    width: 303.2
+    height: 682.4
   m_MinSize: {x: 201, y: 226}
   m_MaxSize: {x: 4001, y: 4026}
   m_ActualView: {fileID: 15}
@@ -214,10 +214,10 @@ MonoBehaviour:
   m_Children: []
   m_Position:
     serializedVersion: 2
-    x: 303
+    x: 303.2
     y: 0
-    width: 1670
-    height: 879
+    width: 1669.6001
+    height: 682.4
   m_MinSize: {x: 202, y: 226}
   m_MaxSize: {x: 4002, y: 4026}
   m_ActualView: {fileID: 16}
@@ -244,9 +244,9 @@ MonoBehaviour:
   m_Position:
     serializedVersion: 2
     x: 0
-    y: 879
-    width: 1973
-    height: 398
+    y: 682.4
+    width: 1972.8
+    height: 308
   m_MinSize: {x: 231, y: 276}
   m_MaxSize: {x: 10001, y: 10026}
   m_ActualView: {fileID: 18}
@@ -270,10 +270,10 @@ MonoBehaviour:
   m_Children: []
   m_Position:
     serializedVersion: 2
-    x: 1973
+    x: 1972.8
     y: 0
-    width: 571
-    height: 1277
+    width: 571.19995
+    height: 990.4
   m_MinSize: {x: 276, y: 76}
   m_MaxSize: {x: 4001, y: 4026}
   m_ActualView: {fileID: 20}
@@ -4936,8 +4936,8 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 24
-    width: 302
-    height: 853
+    width: 302.2
+    height: 656.4
   m_SerializedDataModeController:
     m_DataMode: 0
     m_PreferredDataMode: 0
@@ -5001,10 +5001,10 @@ MonoBehaviour:
     m_TextWithWhitespace: "Scene\u200B"
   m_Pos:
     serializedVersion: 2
-    x: 304
+    x: 304.2
     y: 24
-    width: 1668
-    height: 853
+    width: 1667.6001
+    height: 656.4
   m_SerializedDataModeController:
     m_DataMode: 0
     m_PreferredDataMode: 0
@@ -5391,9 +5391,9 @@ MonoBehaviour:
   m_AudioPlay: 0
   m_DebugDrawModesUseInteractiveLightBakingData: 0
   m_Position:
-    m_Target: {x: -104.23349, y: 21.953695, z: -56.43878}
+    m_Target: {x: -81.98228, y: -25.935333, z: -47.494495}
     speed: 2
-    m_Value: {x: -68.66481, y: -32.339237, z: -41.5587}
+    m_Value: {x: -104.23349, y: 21.953695, z: -56.43878}
   m_RenderMode: 0
   m_CameraMode:
     drawMode: 0
@@ -5409,14 +5409,14 @@ MonoBehaviour:
     showImageEffects: 1
     showParticleSystems: 1
     showVisualEffectGraphs: 1
-    m_FxEnabled: 0
+    m_FxEnabled: 1
   m_Grid:
     xGrid:
       m_Fade:
         m_Target: 0
         speed: 2
         m_Value: 0
-      m_Color: {r: 0.3304557, g: 0.8387946, b: 0.8867924, a: 0.4}
+      m_Color: {r: 0.5, g: 0.5, b: 0.5, a: 0.4}
       m_Pivot: {x: 0, y: 0, z: 0}
       m_Size: {x: 0.5, y: 0.5}
     yGrid:
@@ -5424,7 +5424,7 @@ MonoBehaviour:
         m_Target: 1
         speed: 2
         m_Value: 1
-      m_Color: {r: 0.3304557, g: 0.8387946, b: 0.8867924, a: 0.4}
+      m_Color: {r: 0.5, g: 0.5, b: 0.5, a: 0.4}
       m_Pivot: {x: 0, y: 0, z: 0}
       m_Size: {x: 1, y: 1}
     zGrid:
@@ -5432,20 +5432,20 @@ MonoBehaviour:
         m_Target: 0
         speed: 2
         m_Value: 0
-      m_Color: {r: 0.3304557, g: 0.8387946, b: 0.8867924, a: 0.4}
+      m_Color: {r: 0.5, g: 0.5, b: 0.5, a: 0.4}
       m_Pivot: {x: 0, y: 0, z: 0}
       m_Size: {x: 0.5, y: 0.5}
     m_ShowGrid: 1
     m_GridAxis: 1
     m_gridOpacity: 0.5
   m_Rotation:
-    m_Target: {x: -0.19670406, y: 0.73908514, z: -0.24419063, w: -0.5963782}
+    m_Target: {x: 0.35140237, y: 0.61649007, z: -0.35947138, w: 0.6074353}
     speed: 2
-    m_Value: {x: -0.19760388, y: 0.73486835, z: -0.24157771, w: -0.60213065}
+    m_Value: {x: -0.19668092, y: 0.7389982, z: -0.2441619, w: -0.59630805}
   m_Size:
-    m_Target: 13.841297
+    m_Target: 53.267616
     speed: 2
-    m_Value: 10.000014
+    m_Value: 13.841297
   m_Ortho:
     m_Target: 0
     speed: 2
@@ -5540,9 +5540,9 @@ MonoBehaviour:
   m_Pos:
     serializedVersion: 2
     x: 0
-    y: 903
-    width: 1972
-    height: 372
+    y: 706.4
+    width: 1971.8
+    height: 282
   m_SerializedDataModeController:
     m_DataMode: 0
     m_PreferredDataMode: 0
@@ -5584,7 +5584,7 @@ MonoBehaviour:
     scrollPos: {x: 0, y: 0}
     m_SelectedIDs: 3eb60000
     m_LastClickedID: 46654
-    m_ExpandedIDs: 0000000078b400007ab400007cb400007eb4000080b4000082b4000002b6000000ca9a3b
+    m_ExpandedIDs: 00000000a0b30000a2b30000a4b30000a6b30000a8b30000aab30000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -5613,7 +5613,7 @@ MonoBehaviour:
     scrollPos: {x: 0, y: 0}
     m_SelectedIDs: 
     m_LastClickedID: 0
-    m_ExpandedIDs: 0000000078b400007ab400007cb400007eb4000080b4000082b40000
+    m_ExpandedIDs: 00000000a0b30000a2b30000a4b30000a6b30000a8b30000aab30000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -5730,10 +5730,10 @@ MonoBehaviour:
     m_TextWithWhitespace: "Inspector\u200B"
   m_Pos:
     serializedVersion: 2
-    x: 1974
+    x: 1973.8
     y: 24
-    width: 570
-    height: 1251
+    width: 570.19995
+    height: 964.4
   m_SerializedDataModeController:
     m_DataMode: 0
     m_PreferredDataMode: 0


### PR DESCRIPTION
The clue spawner logic has been re-worked to rely on zones rather than individual spawn points. Simple zones generate a clue within that area, complex zones have a list of pre-set clue spawn points.

The previously implemented default spawn point logic will **not** respect this change, and clues should now be updated to have default spawn zones instead of specific spawn points.